### PR TITLE
feat: ApplicationException, Handler 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,9 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'io.springfox:springfox-swagger2:3.0.0'
-	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation 'javax.validation:validation-api'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modagbul/BE/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/modagbul/BE/global/config/swagger/SwaggerConfig.java
@@ -46,8 +46,7 @@ public class SwaggerConfig {
 
     public ApiInfo apiInfo() {
         return new ApiInfoBuilder()
-                .title("Rest API Documentation")
-                .description("MOING")
+                .title("MOING Rest API Documentation")
                 .license("modagbul.kusitms.27@gmail.com")
                 .version("1.0")
                 .build();

--- a/src/main/java/com/modagbul/BE/global/dto/ErrorResponse.java
+++ b/src/main/java/com/modagbul/BE/global/dto/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.modagbul.BE.global.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+    private LocalDateTime timeStamp;
+    private String errorCode;
+    private String message;
+
+    public ErrorResponse(String errorCode, String message) {
+        this.timeStamp = LocalDateTime.now().withNano(0);
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/exception/ApplicationException.java
+++ b/src/main/java/com/modagbul/BE/global/exception/ApplicationException.java
@@ -1,0 +1,23 @@
+package com.modagbul.BE.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class ApplicationException extends RuntimeException {
+
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+
+    protected ApplicationException(String errorCode, HttpStatus httpStatus, String message) {
+        super(message);
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/modagbul/BE/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.modagbul.BE.global.exception;
+
+import com.modagbul.BE.global.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static java.util.Objects.requireNonNull;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ErrorResponse> handleApplicationException(ApplicationException ex) {
+        log.warn(LOG_FORMAT, ex.getClass().getSimpleName(), ex.getErrorCode(), ex.getMessage());
+        return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getErrorCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        String errorCode = requireNonNull(ex.getFieldError()).getDefaultMessage();
+        log.warn(LOG_FORMAT, ex.getClass().getSimpleName(), errorCode, ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value()).body(new ErrorResponse(errorCode, ex.getMessage()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex) {
+        String errorCode = "405 METHOD_NOT_ALLOWED";
+        String message = "클라이언트가 사용한 HTTP 메서드가 리소스에서 허용되지 않습니다.";
+        log.warn(LOG_FORMAT, ex.getClass().getSimpleName(), errorCode, ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(errorCode, message);
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        String errorCode = "500 INTERNAL_SERVER_ERROR";
+        String message = "서버에서 요청을 처리하는 동안 오류가 발생했습니다.";
+        log.warn(LOG_FORMAT, ex.getClass().getSimpleName(), errorCode, ex.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(errorCode, message);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}
+
+


### PR DESCRIPTION
## Summary
ApplicationException, GolablExceptionHandler추가

## Describe your changes
ApplicationException 클래스를 만들어서 Global하게 예외가 발생할 것을 처리할 수 있도록 하였다. 
- handlerApplicationException 메소드
- methodArgumentNotValidException 메소드: @Valid 처리 (클라이언트 입력 오류)
- handleHttpRequestMethodNotSupportedException 메소드: 405 METHOD_NOT_ALLOWED 처리
- handleException 메소드: 500 INTERNAL_SERVER_ERROR 처리
