### PR TITLE
feat: social-login(kakao)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,13 +38,14 @@ dependencies {
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 
 	implementation 'com.google.firebase:firebase-admin:8.2.0'
 	implementation 'com.google.firebase:firebase-messaging:23.0.0'
 	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
 	implementation 'org.springframework:spring-context:5.3.15'
 
+	implementation 'com.google.code.gson:gson:2.8.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modagbul/BE/domain/user/constant/UserConstant.java
+++ b/src/main/java/com/modagbul/BE/domain/user/constant/UserConstant.java
@@ -1,0 +1,41 @@
+package com.modagbul.BE.domain.user.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+public class UserConstant {
+    @Getter
+    @RequiredArgsConstructor
+    public enum EUserResponseMessage{
+        LOGIN_SUCCES("카카오 로그인을 했습니다"),
+        SIGN_UP_SUCCESS("회원 가입을 완료했습니다"),
+        CHECK_NICKNAME("닉네임 중복 검사를 하였습니다"),
+        DELETE_SUCCESS("회원 탈퇴를 하였습니다");
+        private final String message;
+    }
+
+    @Getter
+    public enum Role {
+        ROLE_USER, ROLE_ADMIN
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Process {
+        SIGN_UP_ING("회원가입 중-추가 정보를 입력해주세요."),
+        SIGN_UP_SUCCESS("회원가입이 완료되었습니다"),
+        LOGIN_SUCCESS("로그인이 완료되었습니다");
+        private final String message;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum UserExceptionList{
+        CONNECTION_ERROR("U0001", HttpStatus.UNAUTHORIZED, "AccessToken 값이 잘못되었습니다"),
+        NOT_HAVE_EMAIL_ERROR("U0002", HttpStatus.NOT_FOUND, "해당 email로 User를 찾을 수 없습니다.");
+        private final String errorCode;
+        private final HttpStatus httpStatus;
+        private final String message;
+    }
+}

--- a/src/main/java/com/modagbul/BE/domain/user/controller/UserController.java
+++ b/src/main/java/com/modagbul/BE/domain/user/controller/UserController.java
@@ -1,0 +1,53 @@
+package com.modagbul.BE.domain.user.controller;
+
+import com.modagbul.BE.domain.user.dto.UserDto;
+import com.modagbul.BE.domain.user.dto.UserDto.CheckNicknameResponse;
+import com.modagbul.BE.domain.user.dto.UserDto.LoginRequest;
+import com.modagbul.BE.domain.user.dto.UserDto.LoginResponse;
+import com.modagbul.BE.domain.user.service.UserService;
+import com.modagbul.BE.global.dto.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static com.modagbul.BE.domain.user.constant.UserConstant.EUserResponseMessage.*;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/v1/users")
+@Api(tags = "User API")
+public class UserController {
+
+    private UserService userService;
+
+    @ApiOperation(value = "카카오 로그인", notes = "카카오 로그인을 합니다.")
+    @PostMapping("/signin")
+    public ResponseEntity<ResponseDto<LoginResponse>> signin(@Valid @RequestBody LoginRequest loginRequest){
+        return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(),LOGIN_SUCCES.getMessage(),this.userService.login(loginRequest)));
+    }
+
+    @ApiOperation(value="닉네임 중복 검사", notes="닉네임 중복 검사를 합니다.")
+    @GetMapping("/check/{nickName}")
+    public ResponseEntity<ResponseDto<CheckNicknameResponse>> checkNickname(@PathVariable String nickName){
+        return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), CHECK_NICKNAME.getMessage(), this.userService.checkNickname(nickName)));
+    }
+
+    @ApiOperation(value="추가 정보 입력", notes="추가 정보를 입력합니다.")
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseDto<LoginResponse>> kakaoSingup(@Valid @RequestBody UserDto.AdditionInfoRequest additionInfoRequest){
+        return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), SIGN_UP_SUCCESS.getMessage(),this.userService.signup(additionInfoRequest)));
+    }
+
+    @ApiOperation(value = "회원 탈퇴", notes = "회원 탈퇴를 합니다.")
+    @PostMapping("/delete")
+    public ResponseEntity<ResponseDto> delete(@Valid @RequestBody LoginRequest loginRequest){
+        this.userService.deleteAccount(loginRequest);
+        return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), DELETE_SUCCESS.getMessage()));
+    }
+
+}

--- a/src/main/java/com/modagbul/BE/domain/user/dto/UserDto.java
+++ b/src/main/java/com/modagbul/BE/domain/user/dto/UserDto.java
@@ -1,0 +1,76 @@
+package com.modagbul.BE.domain.user.dto;
+
+import com.modagbul.BE.global.dto.TokenInfoResponse;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+public abstract class UserDto {
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    @ApiModel(description = "카카오 로그인을 위한 요청 객체")
+    @NoArgsConstructor
+    public static class LoginRequest {
+        @NotBlank(message = "카카오 액세스 토큰을 입력해주세요.")
+        @ApiModelProperty(notes = "카카오 accessToken을 주세요.")
+        private String token;
+
+        public void setToken(String token) {
+            this.token = token;
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ApiModel(description = "로그인을 위한 응답 객체")
+    public static class LoginResponse {
+        private String accessToken;
+        private String refreshToken;
+        private String process;
+
+        public static LoginResponse from(TokenInfoResponse tokenInfoResponse, String process) {
+            return LoginResponse.builder()
+                    .accessToken(tokenInfoResponse.getAccessToken())
+                    .refreshToken(tokenInfoResponse.getRefreshToken())
+                    .process(process)
+                    .build();
+        }
+    }
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ApiModel(description = "추가 정보 입력을 위한 요청 객체")
+    public static class AdditionInfoRequest {
+        @NotBlank(message = "자체 jwt 액세스 토큰을 입력해주세요.")
+        @ApiModelProperty(notes = "자체 액세스 토큰을 입력해 주세요.")
+        private String accessToken;
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @ApiModelProperty(notes = "닉네임을 입력해 주세요.")
+        private String nickName;
+
+        @NotBlank(message = "주소를 입력해주세요.")
+        @ApiModelProperty(notes = "주소를 입력해주세요.")
+        private String address;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ApiModel(description = "닉네임 중복 검사를 위한 응답 객체")
+    public static class CheckNicknameResponse {
+        private String result;
+    }
+
+}

--- a/src/main/java/com/modagbul/BE/domain/user/entity/User.java
+++ b/src/main/java/com/modagbul/BE/domain/user/entity/User.java
@@ -1,4 +1,65 @@
 package com.modagbul.BE.domain.user.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.modagbul.BE.domain.user.constant.UserConstant.Role;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column
+    private String email;
+
+    @Column
+    private String imageUrl;
+
+    @Column
+    private String gender;
+
+    @Column
+    private String age_range;
+
+    @Column
+    private boolean isDeleted;
+
+    // 추가정보
+    @Column
+    private String nickName;
+
+    @Column
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Builder
+    public User(String email, String imageUrl, String gender, String age_range, Role role){
+        this.email=email;
+        this.imageUrl=imageUrl;
+        this.gender=gender;
+        this.age_range=age_range;
+        this.role=role;
+    }
+
+    public void setUser(String nickName, String address){
+        this.nickName=nickName;
+        this.address=address;
+    }
+
+    public void setDeleted(){
+        this.isDeleted=true;
+    }
 }

--- a/src/main/java/com/modagbul/BE/domain/user/exception/ConnException.java
+++ b/src/main/java/com/modagbul/BE/domain/user/exception/ConnException.java
@@ -1,0 +1,14 @@
+package com.modagbul.BE.domain.user.exception;
+
+import com.modagbul.BE.domain.user.constant.UserConstant;
+
+import static com.modagbul.BE.domain.user.constant.UserConstant.UserExceptionList.CONNECTION_ERROR;
+
+public class ConnException extends UserException{
+
+    public ConnException(){
+        super(CONNECTION_ERROR.getErrorCode(),
+                CONNECTION_ERROR.getHttpStatus(),
+                CONNECTION_ERROR.getMessage());
+    }
+}

--- a/src/main/java/com/modagbul/BE/domain/user/exception/NotHaveEmailException.java
+++ b/src/main/java/com/modagbul/BE/domain/user/exception/NotHaveEmailException.java
@@ -1,0 +1,13 @@
+package com.modagbul.BE.domain.user.exception;
+
+import com.modagbul.BE.domain.user.constant.UserConstant;
+
+import static com.modagbul.BE.domain.user.constant.UserConstant.UserExceptionList.NOT_HAVE_EMAIL_ERROR;
+
+public class NotHaveEmailException extends UserException{
+    public NotHaveEmailException(){
+        super(NOT_HAVE_EMAIL_ERROR.getErrorCode(),
+                NOT_HAVE_EMAIL_ERROR.getHttpStatus(),
+                NOT_HAVE_EMAIL_ERROR.getMessage());
+    }
+}

--- a/src/main/java/com/modagbul/BE/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/modagbul/BE/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.modagbul.BE.domain.user.repository;
+
+import com.modagbul.BE.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByNickName(String nickName);
+}

--- a/src/main/java/com/modagbul/BE/domain/user/service/UserService.java
+++ b/src/main/java/com/modagbul/BE/domain/user/service/UserService.java
@@ -1,0 +1,15 @@
+package com.modagbul.BE.domain.user.service;
+
+import com.modagbul.BE.domain.user.dto.UserDto;
+import com.modagbul.BE.domain.user.dto.UserDto.CheckNicknameResponse;
+import com.modagbul.BE.domain.user.dto.UserDto.LoginResponse;
+import com.modagbul.BE.domain.user.entity.User;
+
+
+public interface UserService{
+    LoginResponse login(UserDto.LoginRequest loginRequest);
+    LoginResponse signup(UserDto.AdditionInfoRequest additionInfoRequest);
+    void deleteAccount(UserDto.LoginRequest loginRequest);
+    CheckNicknameResponse checkNickname(String nickName);
+    User validateEmail(String email);
+}

--- a/src/main/java/com/modagbul/BE/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/modagbul/BE/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,199 @@
+package com.modagbul.BE.domain.user.service;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.modagbul.BE.domain.user.dto.UserDto;
+import com.modagbul.BE.domain.user.dto.UserDto.CheckNicknameResponse;
+import com.modagbul.BE.domain.user.dto.UserDto.LoginResponse;
+import com.modagbul.BE.domain.user.entity.User;
+import com.modagbul.BE.domain.user.exception.ConnException;
+import com.modagbul.BE.domain.user.exception.NotHaveEmailException;
+import com.modagbul.BE.domain.user.repository.UserRepository;
+import com.modagbul.BE.global.config.jwt.TokenProvider;
+import com.modagbul.BE.global.config.security.util.SecurityUtils;
+import com.modagbul.BE.global.dto.TokenInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.modagbul.BE.domain.user.constant.UserConstant.Process.LOGIN_SUCCESS;
+import static com.modagbul.BE.domain.user.constant.UserConstant.Process.SIGN_UP_ING;
+import static com.modagbul.BE.domain.user.constant.UserConstant.Role.ROLE_USER;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    private final String LOGIN_URL = "https://kapi.kakao.com/v2/user/me";
+    private final String DELETE_URL = "https://kapi.kakao.com/v1/user/unlink";
+    private final String KAKAO_ACOUNT = "kakao_account";
+    private final String VALID_NICKNAME="가능한 닉네임입니다";
+    private final String EXISTED_NCIKNAME="이미 존재하는 닉네임입니다";
+
+    @Override
+    public LoginResponse login(UserDto.LoginRequest loginRequest) {
+        //1. 프론트에게 받은 액세스 토큰 이용해서 사용자 정보 가져오기
+        String token = loginRequest.getToken();
+        JsonObject userInfo = connectKakao(LOGIN_URL, token);
+        String email = getEmail(userInfo);
+        String pictureUrl = getPictureUrl(userInfo);
+        String gender = getGender(userInfo);
+        String age_range = getAgeRange(userInfo);
+        User user = saveUser(email, pictureUrl, gender, age_range);
+        boolean isSignedUp = user.getNickName() != null;
+        //2. 스프링 시큐리티 처리
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(String.valueOf(ROLE_USER)));
+        OAuth2User userDetails = createOAuth2UserByJson(authorities, userInfo, email);
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(userDetails, authorities, "email");
+        auth.setDetails(userDetails);
+        //3. JWT 토큰 생성
+        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, isSignedUp);
+        String message = isSignedUp ? LOGIN_SUCCESS.getMessage() : SIGN_UP_ING.getMessage();
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        return LoginResponse.from(tokenInfoResponse, message);
+    }
+
+    @Override
+    public LoginResponse signup(UserDto.AdditionInfoRequest additionInfoRequest) {
+        //추가 정보 입력 시
+        //1. 프론트엔드에게 받은 (자체) 액세스 토큰 이용해서 사용자 이메일 가져오기
+        Authentication authentication = tokenProvider.getAuthentication(additionInfoRequest.getAccessToken());
+        User user = userRepository.findByEmail(authentication.getName()).get();
+        //2. 추가 정보 저장
+        user.setUser(additionInfoRequest.getNickName(), additionInfoRequest.getAddress());
+        userRepository.save(user);
+        //3. 스프링 시큐리티 처리
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(String.valueOf(ROLE_USER)));
+        OAuth2User userDetails = createOAuth2UserByUser(authorities, user, additionInfoRequest);
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(userDetails, authorities, "email");
+        auth.setDetails(userDetails);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        //4. JWT 토큰 생성
+        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true);
+        return LoginResponse.from(tokenInfoResponse, LOGIN_SUCCESS.getMessage());
+    }
+
+    @Override
+    public void deleteAccount(UserDto.LoginRequest loginRequest) {
+        String token = loginRequest.getToken();
+        JsonObject response = connectKakao(DELETE_URL, token);
+        User user = SecurityUtils.getLoggedInUser();
+        user.setDeleted();
+        userRepository.save(user);
+    }
+
+    @Override
+    public CheckNicknameResponse checkNickname(String nickName) {
+        if(this.userRepository.findByNickName(nickName.trim()).isPresent()){
+            return new CheckNicknameResponse(EXISTED_NCIKNAME);
+        }else{
+            return new CheckNicknameResponse(VALID_NICKNAME);
+        }
+    }
+
+    @Override
+    public User validateEmail(String email) {
+        return this.userRepository.findByEmail(email).orElseThrow(NotHaveEmailException::new);
+    }
+
+    private OAuth2User createOAuth2UserByUser(List<GrantedAuthority> authorities, User user, UserDto.AdditionInfoRequest additionInfoRequest) {
+        Map userMap = new HashMap<String, String>();
+        userMap.put("email", user.getEmail());
+        userMap.put("pictureUrl", user.getImageUrl());
+        userMap.put("nickName", user.getNickName());
+        userMap.put("address", user.getAddress());
+        OAuth2User userDetails = new DefaultOAuth2User(authorities, userMap, "email");
+        return userDetails;
+    }
+
+    private OAuth2User createOAuth2UserByJson(List<GrantedAuthority> authorities, JsonObject userInfo, String email) {
+        Map userMap = new HashMap<String, String>();
+        userMap.put("email", email);
+        userMap.put("pictureUrl", getPictureUrl(userInfo));
+        userMap.put("gender", getGender(userInfo));
+        userMap.put("age_range", getAgeRange(userInfo));
+        authorities.add(new SimpleGrantedAuthority(String.valueOf(ROLE_USER)));
+        OAuth2User userDetails = new DefaultOAuth2User(authorities, userMap, "email");
+        return userDetails;
+    }
+    private JsonObject connectKakao(String reqURL, String token) {
+        try {
+            URL url = new URL(reqURL);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Authorization", "Bearer " + token);
+            if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                throw new ConnException();
+            }
+            BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+            JsonObject json = JsonParser.parseString(response.toString()).getAsJsonObject();
+            return json;
+        } catch (IOException e) {
+            throw new ConnException();
+        }
+    }
+
+    private String getEmail(JsonObject userInfo) {
+        if (userInfo.getAsJsonObject(KAKAO_ACOUNT).get("has_email").getAsBoolean()) {
+            return userInfo.getAsJsonObject(KAKAO_ACOUNT).get("email").getAsString();
+        }
+        throw new NotHaveEmailException();
+    }
+
+    private String getPictureUrl(JsonObject userInfo) {
+        return userInfo.getAsJsonObject("properties").get("profile_image").getAsString();
+    }
+
+    private String getGender(JsonObject userInfo) {
+        if (userInfo.getAsJsonObject(KAKAO_ACOUNT).get("has_gender").getAsBoolean() &&
+                !userInfo.getAsJsonObject(KAKAO_ACOUNT).get("gender_needs_agreement").getAsBoolean()) {
+            return userInfo.getAsJsonObject(KAKAO_ACOUNT).get("gender").getAsString();
+        }
+        return "동의안함";
+    }
+
+    private String getAgeRange(JsonObject userInfo) {
+        String KAKAO_ACOUNT = "kakao_account";
+        if (userInfo.getAsJsonObject(KAKAO_ACOUNT).get("has_age_range").getAsBoolean() &&
+                !userInfo.getAsJsonObject(KAKAO_ACOUNT).get("age_range_needs_agreement").getAsBoolean()) {
+            return userInfo.getAsJsonObject(KAKAO_ACOUNT).get("age_range").getAsString();
+        }
+        return "동의안함";
+    }
+
+    private User saveUser(String email, String pictureUrl, String gender, String ageRange) {
+        User user = new User(email, pictureUrl, gender, ageRange, ROLE_USER);
+        if (!userRepository.findByEmail(email).isPresent()) {
+            return userRepository.save(user);
+        }
+        return userRepository.findByEmail(email).get();
+    }
+
+}

--- a/src/main/java/com/modagbul/BE/global/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/modagbul/BE/global/config/jwt/JwtAuthenticationEntryPoint.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 /**
  * 인증되지 않은 사용자가 보호된 리소스에 액세스 할 때 호출
@@ -20,7 +21,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         String exception = (String)request.getAttribute("exception");
-        if(exception == null) setResponse(response, JWTExceptionList.UNKNOWN_ERROR);
+        if(exception.equals(JWTExceptionList.ADDITIONAL_REQUIRED_TOKEN.getErrorCode())) setResponse(response, JWTExceptionList.ADDITIONAL_REQUIRED_TOKEN);
+        else if(exception == null) setResponse(response, JWTExceptionList.UNKNOWN_ERROR);
             //잘못된 타입의 토큰인 경우
         else if(exception.equals(JWTExceptionList.ILLEGAL_TOKEN.getErrorCode())) setResponse(response, JWTExceptionList.ILLEGAL_TOKEN);
             //토큰 만료된 경우
@@ -38,6 +40,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
         JSONObject responseJson = new JSONObject();
+        responseJson.put("timestamp", LocalDateTime.now().withNano(0).toString());
         responseJson.put("message", exceptionCode.getMessage());
         responseJson.put("errorCode", exceptionCode.getErrorCode());
 

--- a/src/main/java/com/modagbul/BE/global/config/jwt/constants/JwtConstants.java
+++ b/src/main/java/com/modagbul/BE/global/config/jwt/constants/JwtConstants.java
@@ -13,8 +13,9 @@ public class JwtConstants {
         EXPIRED_TOKEN("J0003", HttpStatus.UNAUTHORIZED,"만료된 토큰입니다."),
         UNSUPPORTED_TOKEN("J0004", HttpStatus.UNAUTHORIZED, "지원되지 않는 토큰입니다."),
         ACCESS_DENIED("J0005", HttpStatus.UNAUTHORIZED,"접근이 거부되었습니다."),
-        ILLEGAL_TOKEN("J0006", HttpStatus.UNAUTHORIZED,"JWT 토큰이 잘못되었습니다.");
+        ILLEGAL_TOKEN("J0006", HttpStatus.UNAUTHORIZED,"JWT 토큰이 잘못되었습니다."),
 
+        ADDITIONAL_REQUIRED_TOKEN("J0007", HttpStatus.UNAUTHORIZED,"추가 정보를 입력해야 합니다.");
         private final String errorCode;
         private final HttpStatus httpStatus;
         private final String message;

--- a/src/main/java/com/modagbul/BE/global/config/jwt/exception/AdditionalInfoException.java
+++ b/src/main/java/com/modagbul/BE/global/config/jwt/exception/AdditionalInfoException.java
@@ -1,0 +1,11 @@
+package com.modagbul.BE.global.config.jwt.exception;
+
+import static com.modagbul.BE.global.config.jwt.constants.JwtConstants.JWTExceptionList.ADDITIONAL_REQUIRED_TOKEN;
+
+public class AdditionalInfoException extends JwtException{
+    public AdditionalInfoException(){
+        super(ADDITIONAL_REQUIRED_TOKEN.getErrorCode(),
+                ADDITIONAL_REQUIRED_TOKEN.getHttpStatus(),
+                ADDITIONAL_REQUIRED_TOKEN.getMessage());
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/swagger-ui/**").permitAll()
                 .antMatchers("/webjars/**").permitAll()
                 .antMatchers("/v3/api-docs").permitAll()
-                .antMatchers("/api/v1/user/**").permitAll()
+                .antMatchers("/api/v1/users/**").permitAll()
 //                .anyRequest().authenticated()
                 .anyRequest().permitAll() //우선 다 열어놓을게요
                 .and()

--- a/src/main/java/com/modagbul/BE/global/config/security/constants/SecurityConstants.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/constants/SecurityConstants.java
@@ -10,7 +10,8 @@ public class SecurityConstants {
     public enum SecurityExceptionList {
         NO_AUTHENTICATION_FOUND("S0001", HttpStatus.UNAUTHORIZED, "보안 컨텍스트에서 인증 정보를 찾을 수 없습니다."),
         NOT_AUTH_WITH_OAUTH2("S0002", HttpStatus.UNAUTHORIZED, "현재 사용자는 OAuth2를 사용하여 인증되지 않았습니다."),
-        LOGGED_IN_NOT_FOUND("S0003", HttpStatus.UNAUTHORIZED, "로그인한 사용자를 찾을 수 없습니다.");
+        LOGGED_IN_NOT_FOUND("S0003", HttpStatus.UNAUTHORIZED, "로그인한 사용자를 찾을 수 없습니다."),
+        REQUIRED_LOGGED_IN("SS0001", HttpStatus.UNAUTHORIZED, "해당 서비스는 로그인이 필요한 서비스입니다.");
         private final String errorCode;
         private final HttpStatus httpStatus;
         private final String message;

--- a/src/main/java/com/modagbul/BE/global/config/security/exception/RequiredLoggedInException.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/exception/RequiredLoggedInException.java
@@ -1,0 +1,12 @@
+package com.modagbul.BE.global.config.security.exception;
+
+import static com.modagbul.BE.global.config.security.constants.SecurityConstants.SecurityExceptionList.REQUIRED_LOGGED_IN;
+
+public class RequiredLoggedInException extends SecurityException{
+    public RequiredLoggedInException() {
+        super(REQUIRED_LOGGED_IN.getErrorCode(),
+                REQUIRED_LOGGED_IN.getHttpStatus(),
+                REQUIRED_LOGGED_IN.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/service/CustomOAuth2UserService.java
@@ -1,0 +1,39 @@
+package com.modagbul.BE.global.config.security.service;
+
+import com.modagbul.BE.global.dto.OAuth2Attribute;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+import static com.modagbul.BE.domain.user.constant.UserConstant.Role.ROLE_USER;
+
+@Service
+@Slf4j
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuth2Attribute oAuth2Attribute =
+                OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        log.info("{}", oAuth2Attribute);
+
+        var memberAttribute = oAuth2Attribute.convertToMap();
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(String.valueOf(ROLE_USER))), memberAttribute, "email");
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/security/service/CustomUserDetails.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/service/CustomUserDetails.java
@@ -1,0 +1,62 @@
+package com.modagbul.BE.global.config.security.service;
+
+import com.modagbul.BE.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(this.user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/modagbul/BE/global/config/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/service/CustomUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.modagbul.BE.global.config.security.service;
+
+import com.modagbul.BE.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserService userService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return new CustomUserDetails(this.userService.validateEmail(email));
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/security/util/SecurityUtils.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/util/SecurityUtils.java
@@ -1,8 +1,12 @@
 package com.modagbul.BE.global.config.security.util;
 
+import com.modagbul.BE.domain.user.entity.User;
+import com.modagbul.BE.domain.user.exception.ConnException;
 import com.modagbul.BE.global.config.security.exception.LoggedInUserNotFoundException;
 import com.modagbul.BE.global.config.security.exception.NoAuthenticationFoundException;
+import com.modagbul.BE.global.config.security.exception.RequiredLoggedInException;
 import com.modagbul.BE.global.config.security.exception.UserNotAuthenticatedWithOAuth2Exception;
+import com.modagbul.BE.global.config.security.service.CustomUserDetails;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -11,28 +15,18 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Transactional
 public class SecurityUtils {
 
-    public static OAuth2User getLoggedInUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null) {
-            throw new NoAuthenticationFoundException();
+    public static User getLoggedInUser() {
+        try {
+            return ((CustomUserDetails) Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication()).getPrincipal()).getUser();
+        } catch (NullPointerException e) {
+            throw new RequiredLoggedInException();
         }
-
-        if (!(authentication instanceof OAuth2AuthenticationToken)) {
-            throw new UserNotAuthenticatedWithOAuth2Exception();
-        }
-
-        OAuth2User loggedInUser = ((OAuth2AuthenticationToken) authentication).getPrincipal();
-
-        if (loggedInUser == null) {
-            throw new LoggedInUserNotFoundException();
-        }
-
-        return loggedInUser;
     }
 
 }

--- a/src/main/java/com/modagbul/BE/global/dto/OAuth2Attribute.java
+++ b/src/main/java/com/modagbul/BE/global/dto/OAuth2Attribute.java
@@ -1,0 +1,62 @@
+package com.modagbul.BE.global.dto;
+
+import com.modagbul.BE.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.modagbul.BE.domain.user.constant.UserConstant.Role.ROLE_USER;
+
+@Getter
+@Builder
+public class OAuth2Attribute {
+    private Map<String, Object> attributes;
+    private String attributeKey;
+    private String email;
+    private String picture;
+
+    public static OAuth2Attribute of(String provider, String attributeKey,
+                                     Map<String, Object> attributes) {
+        switch (provider) {
+            case "kakao":
+                return ofKakao("id", attributes);
+            default:
+                throw new RuntimeException();
+        }
+    }
+
+
+    private static OAuth2Attribute ofKakao(String attributeKey,
+                                           Map<String, Object> attributes) {
+//        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+//        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        return OAuth2Attribute.builder()
+                .email((String) attributes.get("email"))
+                .picture((String)attributes.get("profile_image_url"))
+                .attributes(attributes)
+                .attributeKey(attributeKey)
+                .build();
+    }
+
+
+    public User toEntity() {
+        return User.builder()
+                .email(email)
+                .imageUrl(picture)
+                .role(ROLE_USER)
+                .build();
+    }
+
+    public Map<String, Object> convertToMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", attributeKey);
+        map.put("key", attributeKey);
+        map.put("email", email);
+        map.put("picture", picture);
+
+        return map;
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/exception/ApplicationException.java
+++ b/src/main/java/com/modagbul/BE/global/exception/ApplicationException.java
@@ -18,4 +18,5 @@ public abstract class ApplicationException extends RuntimeException {
     public HttpStatus getHttpStatus() {
         return httpStatus;
     }
+
 }

--- a/src/main/java/com/modagbul/BE/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/modagbul/BE/global/exception/GlobalExceptionHandler.java
@@ -23,8 +23,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ErrorResponse> handleApplicationException(ApplicationException ex) {
+        String errorCode="test";
         log.warn(LOG_FORMAT, ex.getClass().getSimpleName(), ex.getErrorCode(), ex.getMessage());
-        return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(ex.getErrorCode(), ex.getMessage()));
+        return ResponseEntity.status(ex.getHttpStatus()).body(new ErrorResponse(errorCode, ex.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
## 🔥 Summary
카카오 소셜 로그인 구현

## ✏️ Describe your changes
- 프론트엔드에게 카카오 액세스 토큰을 발급받아 로그인, 회원가입 및 추가 정보 입력 처리
- 닉네임 중복성 체크
- 회원 탈퇴

## 🔗 Issue number and link
https://github.com/KUSITMS-MeetUp-2/27th_Meetup_T2_service_back/issues/36#issue-1683697164