### PR TITLE
feat: 소모임 이름 중복검사

### DIFF
--- a/src/main/java/com/modagbul/BE/domain/team/constant/TeamConstant.java
+++ b/src/main/java/com/modagbul/BE/domain/team/constant/TeamConstant.java
@@ -13,7 +13,8 @@ public class TeamConstant {
         JOIN_TEAM_SUCCESS("소모임 참여 코드 인증에 성공하였습니다"),
         GET_TEAM_INFO_SUCCESS("소모임 수정을 위한 정보를 조회하였습니다"),
         UPDATE_TEAM_SUCCESS("소모임을 수정하였습니다"),
-        GET_TEAM_SUCCESS("모든 소모임을 조회하였습니다");
+        GET_TEAM_SUCCESS("모든 소모임을 조회하였습니다"),
+        CHECK_TEAM_NAME_SUCCESS("소모임 이름 중복 검사를 하였습니다");
         private final String message;
     }
     @Getter
@@ -42,5 +43,13 @@ public class TeamConstant {
         private final String errorCode;
         private final HttpStatus httpStatus;
         private final String message;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum TeamServiceMessage {
+        VALID_TEAMNAME("가능한 소모임 이름입니다"),
+        EXISTED_TEAMNAME("이미 존재하는 소모임 이름입니다");
+        private final String value;
     }
 }

--- a/src/main/java/com/modagbul/BE/domain/team/controller/TeamController.java
+++ b/src/main/java/com/modagbul/BE/domain/team/controller/TeamController.java
@@ -48,12 +48,15 @@ public class TeamController {
         return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), UPDATE_TEAM_SUCCESS.getMessage()));
     }
 
-    //진행 중인 소모임 조회
     @ApiOperation(value="소모임 정보 조회", notes="홈 화면에서 소모임 정보를 조회합니다")
     @GetMapping
     public ResponseEntity<ResponseDto<GetTeamResponse>> getTeam(){
         return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), GET_TEAM_SUCCESS.getMessage(), teamService.getTeam()));
     }
 
-    //소모임 이름 중복 체크
+    @ApiOperation(value="소모임 이름 중복 검사", notes="소모임 이름 중복 검사를 합니다")
+    @GetMapping("/teamname/{teamName}/available")
+    public ResponseEntity<ResponseDto<CheckTeamNameResponse>> checkTeamName(@PathVariable String teamName){
+        return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), CHECK_TEAM_NAME_SUCCESS.getMessage(), teamService.checkTeamName(teamName)));
+    }
 }

--- a/src/main/java/com/modagbul/BE/domain/team/dto/TeamDto.java
+++ b/src/main/java/com/modagbul/BE/domain/team/dto/TeamDto.java
@@ -153,4 +153,12 @@ public abstract class TeamDto {
         private boolean approvalStatus;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ApiModel(description = "닉네임 중복 검사를 위한 응답 객체")
+    public static class CheckTeamNameResponse {
+        private String result;
+    }
 }

--- a/src/main/java/com/modagbul/BE/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/modagbul/BE/domain/team/repository/TeamRepository.java
@@ -1,12 +1,12 @@
 package com.modagbul.BE.domain.team.repository;
 
 import com.modagbul.BE.domain.team.entity.Team;
-import com.modagbul.BE.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositoryCustom {
     Optional<Team> findByInvitationCode(String invitaionCode);
+    Optional<Team> findByName(String teamName);
 
 }

--- a/src/main/java/com/modagbul/BE/domain/team/repository/TeamRepositoryCustomImpl.java
+++ b/src/main/java/com/modagbul/BE/domain/team/repository/TeamRepositoryCustomImpl.java
@@ -1,11 +1,7 @@
 package com.modagbul.BE.domain.team.repository;
 
-import com.modagbul.BE.domain.team.dto.TeamDto;
 import com.modagbul.BE.domain.team.dto.TeamDto.GetTeamResponse;
 import com.modagbul.BE.domain.team.dto.TeamDto.TeamBlock;
-import com.modagbul.BE.domain.team.entity.QTeam;
-import com.modagbul.BE.domain.team_member.entity.QTeamMember;
-import com.modagbul.BE.domain.user.entity.QUser;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -15,7 +11,6 @@ import java.util.List;
 
 import static com.modagbul.BE.domain.team.entity.QTeam.team;
 import static com.modagbul.BE.domain.team_member.entity.QTeamMember.teamMember;
-import static com.modagbul.BE.domain.user.entity.QUser.user;
 
 public class TeamRepositoryCustomImpl implements TeamRepositoryCustom{
     private final JPAQueryFactory queryFactory;
@@ -26,8 +21,8 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom{
 
     @Override
     public GetTeamResponse getTeam(Long userId) {
-        List<TeamBlock> teamBlocks=getTeamBlock(userId);
-        Long inProgressNum=queryFactory.select(team)
+        List<TeamBlock> teamBlocks = getTeamBlock(userId);
+        Long inProgressNum = queryFactory.select(team)
                 .from(team)
                 .join(team.teamMembers, teamMember)
                 .where(teamMember.user.userId.eq(userId))
@@ -37,6 +32,7 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom{
                 .fetchCount();
         return new GetTeamResponse(inProgressNum, teamBlocks);
     }
+
     private List<TeamBlock> getTeamBlock(Long userId){
         return queryFactory.select(Projections.constructor(TeamBlock.class,
                 team.teamId, team.name, team.personnel, team.startDate, team.endDate, team.profileImg, team.approvalStatus))

--- a/src/main/java/com/modagbul/BE/domain/team/service/TeamService.java
+++ b/src/main/java/com/modagbul/BE/domain/team/service/TeamService.java
@@ -12,4 +12,5 @@ public interface TeamService {
     void updateTeam(Long teamId, UpdateTeamRequest updateTeamRequest);
     Team validateTeam(Long teamId);
     GetTeamResponse getTeam();
+    CheckTeamNameResponse checkTeamName(String teamName);
 }

--- a/src/main/java/com/modagbul/BE/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/modagbul/BE/domain/team/service/TeamServiceImpl.java
@@ -1,10 +1,7 @@
 package com.modagbul.BE.domain.team.service;
 
 import com.modagbul.BE.domain.team.dto.TeamDto;
-import com.modagbul.BE.domain.team.dto.TeamDto.CreateTeamRequest;
-import com.modagbul.BE.domain.team.dto.TeamDto.CreateTeamResponse;
-import com.modagbul.BE.domain.team.dto.TeamDto.GetTeamInfo;
-import com.modagbul.BE.domain.team.dto.TeamDto.JoinTeamResponse;
+import com.modagbul.BE.domain.team.dto.TeamDto.*;
 import com.modagbul.BE.domain.team.dto.TeamMapper;
 import com.modagbul.BE.domain.team.entity.Team;
 import com.modagbul.BE.domain.team.exception.AccessException;
@@ -24,6 +21,9 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.time.LocalDate;
+
+import static com.modagbul.BE.domain.team.constant.TeamConstant.TeamServiceMessage.EXISTED_TEAMNAME;
+import static com.modagbul.BE.domain.team.constant.TeamConstant.TeamServiceMessage.VALID_TEAMNAME;
 
 @Service
 @Slf4j
@@ -83,6 +83,15 @@ public class TeamServiceImpl implements TeamService {
     @Override
     public TeamDto.GetTeamResponse getTeam() {
         return teamRepository.getTeam(SecurityUtils.getLoggedInUser().getUserId());
+    }
+
+    @Override
+    public CheckTeamNameResponse checkTeamName(String teamName) {
+        if(teamRepository.findByName(teamName).isPresent()){
+            return new CheckTeamNameResponse(EXISTED_TEAMNAME.getValue());
+        }else{
+            return new CheckTeamNameResponse(VALID_TEAMNAME.getValue());
+        }
     }
 
     private void addTeamMember(Team team) {


### PR DESCRIPTION
## 🔥 Summary
소모임 이름 중복검사

## ✏️ Describe your changes
소모임 이름 중복검사
**주의: 소모임 이름 중복검사하는 메소드가 결과값이 2개이상이면 오류가 발생함 
(== 소모임 이름 메소드 자체가 소모임 이름이 중복해서 저장이 안된다는걸 가정)
즉, 클라이언트에서는 소모임 이름이 중복한다고 결과가 나오면 생성이 안되게 해야 함 

## 🔗 Issue number and link
#98 