### PR TITLE
fix: 회원 탈퇴 관련 처리

### DIFF
--- a/src/main/java/com/modagbul/BE/domain/user/dto/UserDto.java
+++ b/src/main/java/com/modagbul/BE/domain/user/dto/UserDto.java
@@ -51,12 +51,14 @@ public abstract class UserDto {
     public static class LoginResponse {
         private String accessToken;
         private String refreshToken;
+        private String kakaoAccessToken;
         private String process;
 
-        public static LoginResponse from(TokenInfoResponse tokenInfoResponse, String process) {
+        public static LoginResponse from(TokenInfoResponse tokenInfoResponse, String kakaoAccessToken, String process) {
             return LoginResponse.builder()
                     .accessToken(tokenInfoResponse.getAccessToken())
                     .refreshToken(tokenInfoResponse.getRefreshToken())
+                    .kakaoAccessToken(kakaoAccessToken)
                     .process(process)
                     .build();
         }

--- a/src/main/java/com/modagbul/BE/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/modagbul/BE/domain/user/service/UserServiceImpl.java
@@ -16,7 +16,6 @@ import com.modagbul.BE.global.config.security.util.SecurityUtils;
 import com.modagbul.BE.global.dto.TokenInfoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.checkerframework.checker.units.qual.A;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -72,7 +71,7 @@ public class UserServiceImpl implements UserService {
 
         //3. JWT 토큰 생성
         TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, isSignedUp);
-        return LoginResponse.from(tokenInfoResponse, isSignedUp ? LOGIN_SUCCESS.getMessage() : SIGN_UP_ING.getMessage());
+        return LoginResponse.from(tokenInfoResponse, token, isSignedUp ? LOGIN_SUCCESS.getMessage() : SIGN_UP_ING.getMessage());
     }
 
     @Override
@@ -93,7 +92,7 @@ public class UserServiceImpl implements UserService {
 
         //4. JWT 토큰 생성
         TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true);
-        return LoginResponse.from(tokenInfoResponse, LOGIN_SUCCESS.getMessage());
+        return LoginResponse.from(tokenInfoResponse, null, LOGIN_SUCCESS.getMessage());
     }
 
     @Override
@@ -131,7 +130,7 @@ public class UserServiceImpl implements UserService {
         OAuth2AuthenticationToken auth = configureAuthentication(userDetails, authorities);
 
         TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true);
-        return LoginResponse.from(tokenInfoResponse, LOGIN_SUCCESS.getMessage());
+        return LoginResponse.from(tokenInfoResponse, null, LOGIN_SUCCESS.getMessage());
     }
 
 


### PR DESCRIPTION
## 🔥 Summary
회원 탈퇴 관련 처리

## ✏️ Describe your changes
회원 탈퇴 시 카카오 액세스 토큰을 줘야 함 
그래서 카카오 로그인 시 자체 액세스 토큰 외에 카카오 액세스 토큰도 줄 수 있도록 수정

