### PR TITLE
feat/auth:  refresh token 이용해서 재발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 
     implementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-inline:4.6.1'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modagbul/BE/domain/user/constant/UserConstant.java
+++ b/src/main/java/com/modagbul/BE/domain/user/constant/UserConstant.java
@@ -15,7 +15,8 @@ public class UserConstant {
         MYPAGE_UPDATE_SUCCESS("마이페이지 수정이 완료되었습니다"),
         MYPAGE_GET_SUCCESS("마이페이지 로딩이 완료되었습니다"),
         ALARM_GET_SUCCESS("알림 설정 로딩이 완료되었습니다"),
-        ALARM_UPDATE_SUCCESS("알림 설정 수정이 완료되었습니다");
+        ALARM_UPDATE_SUCCESS("알림 설정 수정이 완료되었습니다"),
+        TOKEN_REFRESH_SUCCESS("토큰 재발급을 완료하였습니다");
         private final String message;
     }
 

--- a/src/main/java/com/modagbul/BE/domain/user/controller/UserController.java
+++ b/src/main/java/com/modagbul/BE/domain/user/controller/UserController.java
@@ -47,6 +47,9 @@ public class UserController {
         return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), DELETE_SUCCESS.getMessage()));
     }
 
+
+
+
     //테스트를 위한 API
     @PostMapping("/auth/test")
     public ResponseEntity<ResponseDto<LoginResponse>> login(@Valid @RequestBody TestLoginRequest testLoginRequest){

--- a/src/main/java/com/modagbul/BE/domain/user/dto/UserDto.java
+++ b/src/main/java/com/modagbul/BE/domain/user/dto/UserDto.java
@@ -63,16 +63,20 @@ public abstract class UserDto {
     public static class LoginResponse {
         private String accessToken;
         private String refreshToken;
+        private Long userId;
         private String process;
 
-        public static LoginResponse from(TokenInfoResponse tokenInfoResponse, String process) {
+        public static LoginResponse from(TokenInfoResponse tokenInfoResponse, String process, Long userId) {
             return LoginResponse.builder()
                     .accessToken(tokenInfoResponse.getAccessToken())
                     .refreshToken(tokenInfoResponse.getRefreshToken())
                     .process(process)
+                    .userId(userId)
                     .build();
         }
     }
+
+
     @Getter
     @Builder
     @AllArgsConstructor

--- a/src/main/java/com/modagbul/BE/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/modagbul/BE/domain/user/service/UserServiceImpl.java
@@ -58,8 +58,8 @@ public class UserServiceImpl implements UserService {
         OAuth2AuthenticationToken auth = configureAuthentication(userDetails, authorities);
 
         //3. JWT 토큰 생성
-        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, isSignedUp);
-        return LoginResponse.from(tokenInfoResponse, isSignedUp ? LOGIN_SUCCESS.getMessage() : SIGN_UP_ING.getMessage());
+        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, isSignedUp, user.getUserId());
+        return LoginResponse.from(tokenInfoResponse, isSignedUp ? LOGIN_SUCCESS.getMessage() : SIGN_UP_ING.getMessage(),user.getUserId());
     }
 
     @Override
@@ -79,8 +79,8 @@ public class UserServiceImpl implements UserService {
         OAuth2AuthenticationToken auth = configureAuthentication(userDetails, authorities);
 
         //4. JWT 토큰 생성
-        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true);
-        return LoginResponse.from(tokenInfoResponse, LOGIN_SUCCESS.getMessage());
+        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true, user.getUserId());
+        return LoginResponse.from(tokenInfoResponse, LOGIN_SUCCESS.getMessage(), user.getUserId());
     }
 
     @Override
@@ -117,8 +117,8 @@ public class UserServiceImpl implements UserService {
         OAuth2User userDetails = createOAuth2UserByUser(authorities, user);
         OAuth2AuthenticationToken auth = configureAuthentication(userDetails, authorities);
 
-        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true);
-        return LoginResponse.from(tokenInfoResponse, LOGIN_SUCCESS.getMessage());
+        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true, user.getUserId());
+        return LoginResponse.from(tokenInfoResponse, LOGIN_SUCCESS.getMessage(), user.getUserId());
     }
 
 
@@ -194,7 +194,7 @@ public class UserServiceImpl implements UserService {
      * @return OAuth2User
      */
 
-    private OAuth2User createOAuth2UserByUser(List<GrantedAuthority> authorities, User user) {
+    public OAuth2User createOAuth2UserByUser(List<GrantedAuthority> authorities, User user) {
         Map userMap = new HashMap<String, String>();
         userMap.put("email", user.getEmail());
         userMap.put("pictureUrl", user.getImageUrl());
@@ -223,13 +223,13 @@ public class UserServiceImpl implements UserService {
         return userDetails;
     }
 
-    private List<GrantedAuthority> initAuthorities() {
+    public List<GrantedAuthority> initAuthorities() {
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority(String.valueOf(ROLE_USER)));
         return authorities;
     }
 
-    private OAuth2AuthenticationToken configureAuthentication(OAuth2User userDetails, List<GrantedAuthority> authorities) {
+    public OAuth2AuthenticationToken configureAuthentication(OAuth2User userDetails, List<GrantedAuthority> authorities) {
         OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(userDetails, authorities, "email");
         auth.setDetails(userDetails);
         SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/com/modagbul/BE/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.modagbul.BE.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private String redisPort;
+
+    @Value("${spring.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(Integer.parseInt(redisPort));
+        redisStandaloneConfiguration.setPassword(redisPassword);
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/constant/RefreshTokenConstant.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/constant/RefreshTokenConstant.java
@@ -1,0 +1,23 @@
+package com.modagbul.BE.global.config.redis.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenConstant {
+    @Getter
+    @RequiredArgsConstructor
+    public enum ERefreshTokenMessage {
+        TOKEN_REFRESH_SUCCESS("토큰 재발급을 완료하였습니다");
+        private final String message;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum RefreshTokenExceptionList {
+        NOT_FOUND_TOKEN_ERROR("R0003", HttpStatus.NOT_FOUND, "Refresh-Token을 찾을 수 없습니다. 아예 새롭게 로그인을 하세요");
+        private final String errorCode;
+        private final HttpStatus httpStatus;
+        private final String message;
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/controller/RefreshTokenController.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/controller/RefreshTokenController.java
@@ -1,0 +1,33 @@
+package com.modagbul.BE.global.config.redis.controller;
+
+import com.modagbul.BE.global.config.redis.dto.RefreshTokenDto;
+import com.modagbul.BE.global.config.redis.service.RefreshTokenService;
+import com.modagbul.BE.global.dto.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import static com.modagbul.BE.domain.user.constant.UserConstant.EUserResponseMessage.TOKEN_REFRESH_SUCCESS;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/v1/users")
+@Api(tags = "토큰 재발급 API")
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @ApiOperation(value = "토큰 재발급", notes = "토큰을 재발급합니다 합니다.")
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<ResponseDto<RefreshTokenDto.RefreshTokenResponse>> tokenRefresh(@Valid @RequestBody RefreshTokenDto.RefreshTokenRequest refreshTokenRequest) {
+        return ResponseEntity.ok(ResponseDto.create(HttpStatus.OK.value(), TOKEN_REFRESH_SUCCESS.getMessage(), refreshTokenService.refreshToken(refreshTokenRequest)));
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/dto/RefreshTokenDto.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/dto/RefreshTokenDto.java
@@ -1,0 +1,51 @@
+package com.modagbul.BE.global.config.redis.dto;
+
+import com.modagbul.BE.global.dto.TokenInfoResponse;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public abstract class RefreshTokenDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ApiModel(description = "토큰 재발급을 위한 요청 객체")
+    public static class RefreshTokenRequest {
+
+        @NotBlank(message = "액세스 토큰을 입력해주세요.")
+        @ApiModelProperty(notes = "액세스 토큰을 주세요.")
+        private String accessToken;
+
+        @NotBlank(message = "리프레시 토큰을 입력해주세요.")
+        @ApiModelProperty(notes = "리프레시 토큰을 주세요.")
+        private String refreshToken;
+
+        @NotNull(message = "유저 id를 입력해 주세요.")
+        @ApiModelProperty(notes = "유저 id를 입력해 주세요.")
+        private Long userId;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ApiModel(description = "토큰 재발급을 위한 응답 객체")
+    public static class RefreshTokenResponse {
+        private String accessToken;
+        private String refreshToken;
+
+        public static RefreshTokenResponse from(TokenInfoResponse tokenInfoResponse) {
+            return RefreshTokenResponse.builder()
+                    .accessToken(tokenInfoResponse.getAccessToken())
+                    .refreshToken(tokenInfoResponse.getRefreshToken())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/exception/NotFoundRefreshToken.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/exception/NotFoundRefreshToken.java
@@ -1,0 +1,12 @@
+package com.modagbul.BE.global.config.redis.exception;
+
+import static com.modagbul.BE.global.config.redis.constant.RefreshTokenConstant.RefreshTokenExceptionList.NOT_FOUND_TOKEN_ERROR;
+
+public class NotFoundRefreshToken extends RefreshTokenException{
+    public NotFoundRefreshToken(){
+        super(NOT_FOUND_TOKEN_ERROR.getErrorCode(),
+                NOT_FOUND_TOKEN_ERROR.getHttpStatus(),
+                NOT_FOUND_TOKEN_ERROR.getMessage());
+    }
+
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/exception/RefreshTokenException.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/exception/RefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.modagbul.BE.global.config.redis.exception;
+
+import com.modagbul.BE.global.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public abstract class RefreshTokenException extends ApplicationException {
+    protected RefreshTokenException(String errorCode, HttpStatus httpStatus, String message) {
+        super(errorCode, httpStatus, message);
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/repository/RefreshTokenRepository.java
@@ -1,0 +1,30 @@
+package com.modagbul.BE.global.config.redis.repository;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class RefreshTokenRepository {
+
+    private RedisTemplate redisTemplate;
+
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private long refreshTokenValidityTime;
+
+    public RefreshTokenRepository(final RedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String refreshToken, Long userId) {
+        redisTemplate.opsForValue().set(String.valueOf(userId), refreshToken, refreshTokenValidityTime, TimeUnit.SECONDS);
+    }
+
+    public Optional<String> findById(final Long userId) {
+        String refreshToken=(String)redisTemplate.opsForValue().get(String.valueOf(userId));
+        return Optional.ofNullable(refreshToken);
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/service/RefreshTokenService.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/service/RefreshTokenService.java
@@ -1,0 +1,8 @@
+package com.modagbul.BE.global.config.redis.service;
+
+import com.modagbul.BE.global.config.redis.dto.RefreshTokenDto.RefreshTokenRequest;
+import com.modagbul.BE.global.config.redis.dto.RefreshTokenDto.RefreshTokenResponse;
+
+public interface RefreshTokenService {
+    RefreshTokenResponse refreshToken(RefreshTokenRequest refreshTokenRequest);
+}

--- a/src/main/java/com/modagbul/BE/global/config/redis/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/modagbul/BE/global/config/redis/service/RefreshTokenServiceImpl.java
@@ -1,0 +1,47 @@
+package com.modagbul.BE.global.config.redis.service;
+
+import com.modagbul.BE.domain.user.entity.User;
+import com.modagbul.BE.domain.user.exception.NotFoundEmailException;
+import com.modagbul.BE.domain.user.repository.UserRepository;
+import com.modagbul.BE.domain.user.service.UserServiceImpl;
+import com.modagbul.BE.global.config.jwt.TokenProvider;
+import com.modagbul.BE.global.config.redis.dto.RefreshTokenDto;
+import com.modagbul.BE.global.config.redis.exception.NotFoundRefreshToken;
+import com.modagbul.BE.global.config.redis.repository.RefreshTokenRepository;
+import com.modagbul.BE.global.dto.TokenInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    private final UserServiceImpl userService;
+
+    @Override
+    public RefreshTokenDto.RefreshTokenResponse refreshToken(RefreshTokenDto.RefreshTokenRequest refreshTokenRequest) {
+        //1. refreshToken 검증
+        refreshTokenRepository.findById(refreshTokenRequest.getUserId()).orElseThrow(() -> new NotFoundRefreshToken());
+        //2. 새로운 accessToken 재발급
+        //2.1 시큐리티 설정
+        User user = userRepository.findById(refreshTokenRequest.getUserId()).orElseThrow(() -> new NotFoundEmailException());
+        List<GrantedAuthority> authorities = userService.initAuthorities();
+        OAuth2User userDetails = userService.createOAuth2UserByUser(authorities, user);
+        OAuth2AuthenticationToken auth = userService.configureAuthentication(userDetails, authorities);
+        //2.2 JWT 토큰 생성
+        TokenInfoResponse tokenInfoResponse = tokenProvider.createToken(auth, true, user.getUserId());
+        return RefreshTokenDto.RefreshTokenResponse.from(tokenInfoResponse);
+    }
+}

--- a/src/main/java/com/modagbul/BE/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/SecurityConfig.java
@@ -21,7 +21,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final TokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-//    private final ExceptionHandlerFilter exceptionHandlerFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -54,9 +53,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/v3/api-docs").permitAll()
                 .antMatchers("/api/v1/users/**").permitAll()
                 .antMatchers("/oauth/kakao/**").permitAll()
-//                .antMatchers("/ap1/v1/team/**").authenticated()
                 .anyRequest().authenticated()
-//                .anyRequest().permitAll() //우선 다 열어놓을게요
                 .and()
                 .apply(new JwtSecurityConfig(tokenProvider));
     }

--- a/src/main/java/com/modagbul/BE/global/config/security/service/CustomUserDetails.java
+++ b/src/main/java/com/modagbul/BE/global/config/security/service/CustomUserDetails.java
@@ -60,4 +60,6 @@ public class CustomUserDetails implements UserDetails {
         return true;
     }
 
+    public Long geUserId(){return this.user.getUserId();}
+
 }

--- a/src/test/java/com/modagbul/BE/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/modagbul/BE/domain/user/service/UserServiceImplTest.java
@@ -92,7 +92,7 @@ class UserServiceImplTest {
         given(kakao.getGender(any())).willReturn(mockUser.getGender());
         given(kakao.getPictureUrl(any())).willReturn(mockUser.getImageUrl());
         given(userRepository.findNotDeletedByEmail(anyString())).willReturn(Optional.of(mockUser));
-        given(tokenProvider.createToken(any(OAuth2AuthenticationToken.class), anyBoolean())).willReturn(mockTokenInfoResponse);
+        given(tokenProvider.createToken(any(OAuth2AuthenticationToken.class), anyBoolean(), any())).willReturn(mockTokenInfoResponse);
 
         //when
         LoginResponse result = userService.login(loginRequest);
@@ -117,7 +117,7 @@ class UserServiceImplTest {
         given(kakao.getGender(any())).willReturn(mockUser.getGender());
         given(kakao.getPictureUrl(any())).willReturn(mockUser.getImageUrl());
         given(userRepository.findNotDeletedByEmail(anyString())).willReturn(Optional.of(mockUser));
-        given(tokenProvider.createToken(any(OAuth2AuthenticationToken.class), anyBoolean())).willReturn(mockTokenInfoResponse);
+        given(tokenProvider.createToken(any(OAuth2AuthenticationToken.class), anyBoolean(), any())).willReturn(mockTokenInfoResponse);
 
         //when
         LoginResponse result = userService.login(loginRequest);
@@ -137,7 +137,7 @@ class UserServiceImplTest {
         Authentication mockAuthentication = new TestingAuthenticationToken(mockUser.getEmail(), null);
         given(tokenProvider.getAuthentication(anyString())).willReturn(mockAuthentication);
         given(userRepository.findNotDeletedByEmail(anyString())).willReturn(Optional.of(mockUser));
-        given(tokenProvider.createToken(any(OAuth2AuthenticationToken.class), anyBoolean())).willReturn(mockTokenInfoResponse);
+        given(tokenProvider.createToken(any(OAuth2AuthenticationToken.class), anyBoolean(), any())).willReturn(mockTokenInfoResponse);
 
         //when
         LoginResponse result = userService.signup(additionInfoRequest);


### PR DESCRIPTION
## 🔥 Summary
refresh token 이용해서 재발급

## ✏️ Describe your changes
- token 생성 시 refresh token을 redis에 저장
- key: userId, value:refresh token으로 redis에 저장
- key 이용해서 refresh token 검증 -> 검증해서 맞으면 액세스 토큰 다시 발급

## 🔗 Issue number and link
#126 